### PR TITLE
Respond to backpressure suggestions

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,11 +83,13 @@ FileStream.prototype.pipe = function pipe(dest, options) {
 
 FileStream.prototype.pause = function() {
   this.paused = true
+  this.emit("pause", this.offset)
   return this.offset
 }
 
 FileStream.prototype.resume = function() {
   this.paused = false
+  this.emit("resume", this.offset)
   this.readChunk(this.options.output)
 }
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var EventEmitter = require('events').EventEmitter
 
 module.exports = FileStream
 
-function FileStream(file, options) { 
+function FileStream(file, options) {
   if (!(this instanceof FileStream))
     return new FileStream(file, options)
   options = options || {}
@@ -13,28 +13,34 @@ function FileStream(file, options) {
   this.readable = true
   this.offset = options.offset || 0
   this.paused = false
-  this.chunkSize = this.options.chunkSize || 8128  
+  this.chunkSize = this.options.chunkSize || 8128
 
   var tags = ['name','size','type','lastModifiedDate']
   tags.forEach(function (thing) {
      this[thing] = file[thing]
-   }, this)      
+   }, this)
 }
 
-  
+
 FileStream.prototype._FileReader = function() {
   var self = this
   var reader = new FileReader()
   const outputType = this.options.output
 
   reader.onloadend = function loaded(event) {
-    var data = event.target.result      
+    var data = event.target.result
     if (data instanceof ArrayBuffer)
       data = new Buffer(new Uint8Array(event.target.result))
-    self.dest.write(data)        
+
+    var ok = self.dest.write(data);
+    if (!ok) {
+      self.pause();
+      self.dest.once("drain", self.resume.bind(self))
+    }
+
     if (self.offset < self._file.size) {
       self.emit('progress', self.offset)
-      !self.paused && self.readChunk(outputType)      
+      !self.paused && self.readChunk(outputType)
       return
     }
     self._end()
@@ -57,7 +63,7 @@ FileStream.prototype.readChunk = function(outputType) {
   else if (outputType === 'arraybuffer')
     this.reader.readAsArrayBuffer(slice)
   else if (outputType === 'text')
-    this.reader.readAsText(slice)  
+    this.reader.readAsText(slice)
 }
 
 FileStream.prototype._end = function() {
@@ -65,7 +71,7 @@ FileStream.prototype._end = function() {
     this.dest.end && this.dest.end()
     this.dest.close && this.dest.close()
     this.emit('end', this._file.size)
-  }  
+  }
 }
 
 FileStream.prototype.pipe = function pipe(dest, options) {

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ FileStream.prototype._FileReader = function() {
 
     var ok = self.dest.write(data);
     if (!ok) {
-      self.pause();
+      self.pause()
       self.dest.once("drain", self.resume.bind(self))
     }
 

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ FileStream.prototype._FileReader = function() {
     if (data instanceof ArrayBuffer)
       data = new Buffer(new Uint8Array(event.target.result))
 
-    var ok = self.dest.write(data);
+    var ok = self.dest.write(data)
     if (!ok) {
       self.pause()
       self.dest.once("drain", self.resume.bind(self))

--- a/test.js
+++ b/test.js
@@ -4,21 +4,21 @@ var concat = require('concat-stream');
 var frs = require('./');
 
 drop(document.body, function(files) {
-  var first = files[0], 
+  var first = files[0],
       s = frs(first),
       cursor, paused
 
   test('should read file when one is dropped', function(t) {
-    s.pipe(concat(function(contents) {        
+    s.pipe(concat(function(contents) {
         t.true(contents.length > 0)
-        t.end()       
+        t.end()
     }))
-  })  
-  
+  })
+
   s.on('progress', function(offset){
-  	if (offset / first.size < 0.5 || paused) return  	  		
+  	if (offset / first.size < 0.5 || paused) return
   	test('should pause when over 30% of the file is read', function(t) {
-	    cursor = s.pause()  				
+	    cursor = s.pause()
 	    t.true(cursor / first.size >= 0.5)
 	    t.end()
   	})
@@ -31,14 +31,14 @@ drop(document.body, function(files) {
   	  }, 2000)
   	})
 
-  	paused = true  	
+  	paused = true
   })
 
   s.on('end', function(offset){
   	test('should return correct offset upon end event', function(t) {
 	    t.true(first.size === offset)
 	    t.end()
-  	})		
+  	})
   })
 
 })


### PR DESCRIPTION
This updates `filereader-stream` to listen to backpressure suggestions from downstream.

This is my first meaningful stream work, and I'm prepared to be told I've done something silly. But it seems to work in empirical testing. Without this patch, filereader-stream has no way to be told to stop reading a very large file into memory.

I haven't included a test, mostly because I think it would take me a long time to figure out how to create an anonymous write stream that establishes a high watermark. Maybe it's simpler than I think? Suggestions welcome.
