### PR TITLE
streams2 and web worker support

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "beefy": "~0.6.0"
   },
   "dependencies": {
-    "inherits": "1.0.0"
-  }  
+    "inherits": "1.0.0",
+    "typedarray-to-buffer": "^3.0.0"
+  }
 }

--- a/readme.md
+++ b/readme.md
@@ -36,14 +36,8 @@ test('should read file when one is dropped', function(t) {
 var createReadStream = require('filereader-stream', [options]);
 ```
 
-`options` is optional and can specify `output`. Possible values are:
-
-* `arraybuffer` [default]
-* `binary` 
-* `dataurl`
-* `text`
-
-You can also specify `chunkSize`, default is `8128`. This is how many bytes will be read and written at a time to the stream you get back for each file.
+`options` is optional and can specify `chunkSize`, default is `16384`. This is how many bytes will be read and written at a 
+time to the stream.
 
 # run the tests
 

--- a/test.js
+++ b/test.js
@@ -10,35 +10,10 @@ drop(document.body, function(files) {
 
   test('should read file when one is dropped', function(t) {
     s.pipe(concat(function(contents) {        
-        t.true(contents.length > 0)
-        t.end()       
+        t.equal(contents.length, first.size)
+        t.equal(s.offset, first.size)
+        t.end()
     }))
   })  
-  
-  s.on('progress', function(offset){
-  	if (offset / first.size < 0.5 || paused) return  	  		
-  	test('should pause when over 30% of the file is read', function(t) {
-	    cursor = s.pause()  				
-	    t.true(cursor / first.size >= 0.5)
-	    t.end()
-  	})
-
-  	test('should resume 2 seconds after pause', function(t) {
-  	  setTimeout(function(){
-   	    s.resume()
-  	    t.true(s.paused === false)
-  	    t.end()
-  	  }, 2000)
-  	})
-
-  	paused = true  	
-  })
-
-  s.on('end', function(offset){
-  	test('should return correct offset upon end event', function(t) {
-	    t.true(first.size === offset)
-	    t.end()
-  	})		
-  })
 
 })


### PR DESCRIPTION
Not sure how you feel about this vs publishing a new module, but this PR ports this module to streams2.  It's a pretty big API change, so it will have to be a major version update so backward compatibility isn't compromised.  Specifically:
- There is no more `output` option - the output is always buffers, or strings according to streams2's `setEncoding` method on readable streams.
- No more `progress` event - it isn't really possible to know the progress of the stream consumers, which isn't necessarily the same as the progress of the file reader.

Otherwise it should work fine: piping still works, etc.

This PR also adds support for web workers in Firefox, where `FileReader` is not supported but `FileReaderSync` is.

Let me know what you think. If it's too big of a change, I can publish as a separate module.
