### PR TITLE
Fix docs typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,9 @@ test('should read file when one is dropped', function(t) {
 # usage
 
 ```js
-var createReadStream = require('filereader-stream', [options]);
+var fileReaderStream = require('filereader-stream');
+
+var createReadStream = fileReaderStream(file, [options]);
 ```
 
 `options` is optional and can specify `output`. Possible values are:


### PR DESCRIPTION
the docs as they are now are a bit misleading. wasn't sure how you would prefer it to be fixed, but this seemed decent.