### PR TITLE
filereader-stream doesn't respect flow control

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ function FileStream(file, options) {
    }, this)      
 }
 
+inherits(FileStream, EventEmitter)
   
 FileStream.prototype._FileReader = function() {
   var self = this
@@ -103,4 +104,3 @@ FileStream.prototype.abort = function() {
   return this.offset
 }
 
-inherits(FileStream, EventEmitter)

--- a/index.js
+++ b/index.js
@@ -27,17 +27,27 @@ FileStream.prototype._FileReader = function() {
   var reader = new FileReader()
   var outputType = this.options.output
 
+  var hasEnded = false
   reader.onloadend = function loaded(event) {
     var data = event.target.result      
     if (data instanceof ArrayBuffer)
       data = new Buffer(new Uint8Array(event.target.result))
-    self.dest.write(data)        
-    if (self.offset < self._file.size) {
-      self.emit('progress', self.offset)
-      !self.paused && self.readChunk(outputType)      
-      return
+    if (hasEnded) {
+      var length = event.lengthComputable
+        ? event.total : new Uint8Array(event.target.result).length;
+      if (length > 0)
+        self.emit('error', new Error("write after end"));
     }
-    self._end()
+    else {
+      self.dest.write(data)
+      if (self.offset < self._file.size) {
+        self.emit('progress', self.offset)
+        !self.paused && self.readChunk(outputType)
+        return
+      }
+      hasEnded = true
+      self._end()
+    }
   }
   reader.onerror = function(e) {
     self.emit('error', e.target.error)

--- a/index.js
+++ b/index.js
@@ -39,14 +39,15 @@ FileStream.prototype._FileReader = function() {
         self.emit('error', new Error("write after end"));
     }
     else {
-      self.dest.write(data)
-      if (self.offset < self._file.size) {
-        self.emit('progress', self.offset)
-        !self.paused && self.readChunk(outputType)
-        return
-      }
-      hasEnded = true
-      self._end()
+      self.dest.write(data, function() {
+        if (self.offset < self._file.size) {
+          self.emit('progress', self.offset)
+          !self.paused && self.readChunk(outputType)
+          return
+        }
+        hasEnded = true
+        self._end()
+      })
     }
   }
   reader.onerror = function(e) {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "beefy": "~0.6.0"
   },
   "dependencies": {
-    "inherits": "1.0.0"
+    "inherits": "^2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/maxogden/filereader-stream",
   "devDependencies": {
     "drag-and-drop-files": "~0.0.1",
-    "concat-stream": "~1.2.1",
+    "concat-stream": "~1.4.8",
     "tape": "~2.3.2",
     "browserify": "~3.11.0",
     "beefy": "~0.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filereader-stream",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Read an HTML5 File object (from e.g. HTML5 drag and drops) as a stream.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filereader-stream",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Read an HTML5 File object (from e.g. HTML5 drag and drops) as a stream.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Currently filereader-stream keeps pushing data unless you explicitly pause it.
Try to use it to upload a file n times larger the amount of RAM you have, and you'll practically kill your browser.

It should not send more until it has received the flush callback.

While implementing this, I saw that it also tends to write after end, a newer concat-stream exposes this in the unit test. It's not a major issue, as we write an empty buffer. The cause is that we get an empty event from the FileReader for some reason after the file is completely read.

This pull request fixes both of the above.
