### PR TITLE
File.lastModifiedDate is deprecated. Use File.lastModified instead.

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = function (file, options) {
   from.name = file.name
   from.size = file.size
   from.type = file.type
-  from.lastModifiedDate = file.lastModifiedDate
+  from.lastModified = file.lastModified
 
   fileReader.onerror = function (err) {
     from.destroy(err)


### PR DESCRIPTION
Calling `file.lastModifiedDate` shows a warning in the Firefox console now:
> File.lastModifiedDate is deprecated. Use File.lastModified instead.

This PR:
- changes the call in the File API to use `file.lastModified`
- ~sets `from.lastModifiedDate` to the value of `file.lastModified` for backwards compat 😸~
- adds `from.lastModified` which is set to the value of `file.lastModified`
