### PR TITLE
Add option to disable automatic buffer conversion

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ module.exports = function (file, options) {
   options = options || {}
   var offset = options.offset || 0
   var chunkSize = options.chunkSize || 1024 * 1024 // default 1MB chunk has tolerable perf on large files
-  var convertBuffers = options.convertBuffers || true
+  var convertBuffers = options.convertBuffers != null ? options.convertBuffers : true
   var fileReader = new FileReader(file)
 
   var from = from2(function (size, cb) {

--- a/index.js
+++ b/index.js
@@ -6,13 +6,14 @@ module.exports = function (file, options) {
   options = options || {}
   var offset = options.offset || 0
   var chunkSize = options.chunkSize || 1024 * 1024 // default 1MB chunk has tolerable perf on large files
+  var convertBuffers = options.convertBuffers || true
   var fileReader = new FileReader(file)
 
   var from = from2(function (size, cb) {
     if (offset >= file.size) return cb(null, null)
     fileReader.onloadend = function loaded (event) {
       var data = event.target.result
-      if (data instanceof ArrayBuffer) data = toBuffer(new Uint8Array(event.target.result))
+      if (convertBuffers && data instanceof ArrayBuffer) data = toBuffer(new Uint8Array(event.target.result))
       cb(null, data)
     }
     var end = offset + chunkSize

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
     "typedarray-to-buffer": "^3.0.4"
   },
   "devDependencies": {
-    "browserify": "~3.11.0",
-    "drag-and-drop-files": "~0.0.1",
-    "standard": "^5.3.1",
-    "tape": "~2.3.2",
+    "browserify": "^16.2.2",
+    "drag-and-drop-files": "^0.0.1",
+    "standard": "^11.0.1",
+    "tape": "~4.9.0",
     "through2": "^2.0.0",
     "wzrd": "^1.3.1"
   }

--- a/readme.md
+++ b/readme.md
@@ -40,6 +40,7 @@ var readStream = fileReaderStream(file, [options])
 
 * `chunkSize` - default `1024 * 1024` (1MB) - How many bytes will be read at a time
 * `offset` - default `0` - Where in the file to start reading
+* `convertBuffers` - default `true` - Option to disable converting ArrayBuffer/typedarraybuffer to buffer using [feross/typedarray-to-buffer](https://github.com/feross/typedarray-to-buffer).
 
 # run the tests
 


### PR DESCRIPTION
I'm doing somethings that want typed arrays, and am experimenting with an option to allow typedarray buffers from filereader-stream.